### PR TITLE
fix: change type of `builders.nixpkgs.settings.args`

### DIFF
--- a/modules/builders/nixpkgs.nix
+++ b/modules/builders/nixpkgs.nix
@@ -16,7 +16,7 @@ in
 
             args = lib.options.create {
               description = "Arguments to pass to the builder.";
-              type = lib.types.any;
+              type = lib.types.attrs.of lib.types.raw;
               default.value = { };
             };
           };


### PR DESCRIPTION
Now it's `lib.types.attrs.of lib.types.any`, which allows it to be partially overridden.