### PR TITLE
feat: add `inputs` argument to Nilla modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ let
     sha256 = "0000000000000000000000000000000000000000000000000000";
   });
 in
-nilla.create ({ config }:
+nilla.create ({ config, inputs }:
   let
     # Get the loaded input data!
-    text = config.inputs.myinput.result;
+    text = inputs.myinput;
   in
   {
     # Include our module in the project.

--- a/default.nix
+++ b/default.nix
@@ -27,6 +27,11 @@ in
                 };
               }
             ];
+          args = {
+            inputs = builtins.mapAttrs
+              (name: value: value.result)
+              config.inputs;
+          };
         };
 
       config = result.config;

--- a/examples/nilla/dep/nilla.nix
+++ b/examples/nilla/dep/nilla.nix
@@ -2,7 +2,7 @@ let
   nilla = import ../../../default.nix;
 
   result =
-    nilla.create ({ config }: {
+    nilla.create ({ config, inputs }: {
       config = {
         inputs = {
           nixpkgs = {
@@ -19,7 +19,7 @@ let
           builder = "nixpkgs";
 
           settings = {
-            pkgs = config.inputs.nixpkgs.result;
+            pkgs = inputs.nixpkgs;
 
             args = { };
 

--- a/examples/nilla/nilla.nix
+++ b/examples/nilla/nilla.nix
@@ -4,7 +4,7 @@ let
   nilla = import "${root}/default.nix";
 
   result =
-    nilla.create ({ lib, config }: {
+    nilla.create ({ lib, inputs }: {
       config = {
         inputs = {
           dep = {
@@ -25,7 +25,7 @@ let
         };
 
         shells.default =
-          config.inputs.dep.result.shells.default;
+          inputs.dep.shells.default;
       };
     });
 in

--- a/examples/packages/nilla.nix
+++ b/examples/packages/nilla.nix
@@ -2,7 +2,7 @@ let
   nilla = import ../../default.nix;
 
   result =
-    nilla.create ({ config }: {
+    nilla.create ({ inputs }: {
       config = {
         inputs = {
           nixpkgs = {
@@ -19,7 +19,7 @@ let
           builder = "nixpkgs";
 
           settings = {
-            pkgs = config.inputs.nixpkgs.result;
+            pkgs = inputs.nixpkgs;
 
             args = { };
 

--- a/examples/shells/nilla.nix
+++ b/examples/shells/nilla.nix
@@ -2,7 +2,7 @@ let
   nilla = import ../../default.nix;
 
   result =
-    nilla.create ({ config }: {
+    nilla.create ({ inputs }: {
       config = {
         inputs = {
           nixpkgs = {
@@ -19,7 +19,7 @@ let
           builder = "nixpkgs";
 
           settings = {
-            pkgs = config.inputs.nixpkgs.result;
+            pkgs = inputs.nixpkgs;
 
             args = { };
 


### PR DESCRIPTION
Loaded inputs are now passed to Nilla modules via `inputs` argument.