### PR TITLE
fix(inputs): Filter __functor from inputs

### DIFF
--- a/modules/inputs/default.nix
+++ b/modules/inputs/default.nix
@@ -1,6 +1,6 @@
 { lib, config }:
 let
-  cfg = config.inputs;
+  cfg = lib.attrs.filter (n: v: n != "__functor") config.inputs;
 
   loaders = lib.attrs.mapToList
     (name: loader: loader // {


### PR DESCRIPTION
npins v7 breaks the current loader because it has a hidden attribute __functor which has no src and causes the assertion to fail