### PR TITLE
Upgrade Aux lib to 1.1.0

### DIFF
--- a/npins/default.nix
+++ b/npins/default.nix
@@ -65,7 +65,9 @@ let
         if pkgs == null then
           {
             inherit (builtins) fetchTarball fetchurl;
-            # For some fucking reason, fetchGit has a different signature than the other builtin fetchers …
+            # Frustratingly, due to flakes and `fetchTree`, `fetchGit`
+            # has a different signature than the other builtin
+            # fetchers
             fetchGit = args: (builtins.fetchGit args).outPath;
           }
         else
@@ -95,7 +97,6 @@ let
               };
           };
 
-      # Dispatch to the correct code path based on the type
       path =
         if spec.type == "Git" then
           mkGitSource fetchers spec
@@ -105,8 +106,8 @@ let
           mkPyPiSource fetchers spec
         else if spec.type == "Channel" then
           mkChannelSource fetchers spec
-        else if spec.type == "Tarball" then
-          mkTarballSource fetchers spec
+        else if spec.type == "Url" || spec.type == "MutableUrl" then
+          mkUrlSource fetchers spec
         else if spec.type == "Container" then
           mkContainerSource pkgs spec
         else
@@ -145,6 +146,8 @@ let
             "https://github.com/${repository.owner}/${repository.repo}.git"
           else if repository.type == "GitLab" then
             "${repository.server}/${repository.repo_path}.git"
+          else if repository.type == "Forgejo" then
+            "${repository.server}/${repository.owner}/${repository.repo}.git"
           else
             throw "Unrecognized repository type ${repository.type}";
         urlToName =
@@ -190,16 +193,20 @@ let
       sha256 = hash;
     };
 
-  mkTarballSource =
-    { fetchTarball, ... }:
+  mkUrlSource =
     {
-      url,
-      locked_url ? url,
-      hash,
+      fetchTarball,
+      fetchurl,
       ...
     }:
-    fetchTarball {
-      url = locked_url;
+    {
+      url,
+      hash,
+      unpack,
+      ...
+    }:
+    (if unpack then fetchTarball else fetchurl) {
+      inherit url;
       sha256 = hash;
     };
 
@@ -209,16 +216,22 @@ let
       image_name,
       image_tag,
       image_digest,
+      hash,
       ...
-    }:
+    }@args:
     if pkgs == null then
       builtins.throw "container sources require passing in a Nixpkgs value: https://github.com/andir/npins/blob/master/README.md#using-the-nixpkgs-fetchers"
     else
-      pkgs.dockerTools.pullImage {
-        imageName = image_name;
-        imageDigest = image_digest;
-        finalImageTag = image_tag;
-      };
+      pkgs.dockerTools.pullImage (
+        {
+          imageName = image_name;
+          imageDigest = image_digest;
+          finalImageTag = image_tag;
+          hash = hash;
+        }
+        // (if args.arch or null != null then { arch = args.arch; } else { })
+      );
+
 in
 mkFunctor (
   {
@@ -229,7 +242,7 @@ mkFunctor (
       if builtins.isPath input then
         # while `readFile` will throw an error anyways if the path doesn't exist,
         # we still need to check beforehand because *our* error can be caught but not the one from the builtin
-        # *piegames sighs*
+        # See: <https://git.lix.systems/lix-project/lix/issues/1098>
         if builtins.pathExists input then
           builtins.fromJSON (builtins.readFile input)
         else
@@ -240,7 +253,7 @@ mkFunctor (
         throw "Unsupported input type ${builtins.typeOf input}, must be a path or an attrset";
     version = data.version;
   in
-  if version == 7 then
+  if version == 8 then
     builtins.mapAttrs (name: spec: mkFunctor (mkSource name spec)) data.pins
   else
     throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -28,17 +28,17 @@
       "version_upper_bound": null,
       "release_prefix": null,
       "submodules": false,
-      "version": "v1.0.1",
-      "revision": "5158499e95b69dfbaa48baadd2e8e25568938657",
-      "url": "https://git.auxolotl.org/api/v1/repos/auxolotl/lib/archive/v1.0.1.tar.gz",
-      "hash": "sha256-xfEIYhQzCPzo9SWs7uSAw8SnkwAwCZusDCgyzNFCmZ8="
+      "version": "v1.1.0",
+      "revision": "6701587e5936187665312fd259d680edb4a2b2c9",
+      "url": "https://git.auxolotl.org/api/v1/repos/auxolotl/lib/archive/v1.1.0.tar.gz",
+      "hash": "sha256-HWG8KSe51gOu0/hSjIwnu6H4pYzZrsWyYjN1Z63XhlY="
     },
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
       "artifact": "nixexprs.tar.xz",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre893393.91c9a64ce2a8/nixexprs.tar.xz",
-      "hash": "sha256-ZpXmozTPldgyUyjILammopnda1An2w/66vKrU+1v1Ew="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1028110.f205b5574fd0/nixexprs.tar.xz",
+      "hash": "sha256-2l8yOB5aYd+05Q9V9Y1YhgbSa1j1o5QX+nvYs5FL80A="
     }
   },
   "version": 8

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -36,9 +36,10 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
+      "artifact": "nixexprs.tar.xz",
       "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre893393.91c9a64ce2a8/nixexprs.tar.xz",
       "hash": "sha256-ZpXmozTPldgyUyjILammopnda1An2w/66vKrU+1v1Ew="
     }
   },
-  "version": 7
+  "version": 8
 }


### PR DESCRIPTION
Fixes #34

- npins format updated for current version of npins
- Aux lib upgraded to [1.1.0](https://git.auxolotl.org/auxolotl/lib/releases/tag/v1.1.0)

No functional changes, tested on `examples/` & own projects.